### PR TITLE
rspamd (lint) and safebrowsing (Py3)

### DIFF
--- a/rspamd/rspamd.py
+++ b/rspamd/rspamd.py
@@ -105,7 +105,7 @@ class RSpamdPlugin(ScannerPlugin):
         # - rspamd does not support gtube
         # - no lint function implemented in workers
         # - may only check tcp connection...
-        self._lint_gtube()
+        allok = allok and self._lint_gtube()
         return allok
     
     
@@ -120,7 +120,7 @@ class RSpamdPlugin(ScannerPlugin):
         
         os.remove(tmpfile)
         print(data)
-    
+        return (None not in data)    
     
     
     def rspamd_json(self, suspect):

--- a/safebrowsing/gglsbl.py
+++ b/safebrowsing/gglsbl.py
@@ -83,6 +83,8 @@ class GGLSBLClient(object):
     def _convert(self, jsondata):
         data = u''
         try:
+            if isinstance(jsondata, bytes): # python3
+                jsondata = jsondata.decode('utf-8')
             data = json.loads(jsondata)
         except Exception as e:
             self.logger.error('data conversion failed: %s' % str(e))


### PR DESCRIPTION
- Change in rspamd lint routine so it fails if rspamd can not be accessed. Currently the
lint will return "OK" even if there's no rspamd process running.
- Python3 fix in safebrowsing plugin