### PR TITLE
encode predigest regardless of python version

### DIFF
--- a/hash_fuzor/fuzor.py
+++ b/hash_fuzor/fuzor.py
@@ -288,17 +288,14 @@ class FuzorDigest(object):
         if self.bodytext_size < self.MINIMUM_BODYTEXT_SIZE:
             return None
         predigest = predigest.strip()
-        if sys.version_info == (2,) and isinstance(predigest, unicode):
-            predigest = predigest.encode('utf-8', 'ignore')
         if len(predigest) < self.MINIMUM_PREDIGEST_SIZE:
             return None
         unmodified = re.sub(r'\[[A-Z0-9:]+\]', '', predigest)
         if len(unmodified) < self.MINIMUM_UNMODIFIED_CONTENT:
             return None
-        try:
-            return hashlib.sha1(predigest).hexdigest()
-        except UnicodeEncodeError:
-            return None
+
+        predigest=predigest.encode('utf-8',errors='ignore')
+        return hashlib.sha1(predigest).hexdigest()
 
 
 


### PR DESCRIPTION
fixes exception on py3.4:

```
  File "/usr/local/fuglu/virtualenv/lib/python3.4/site-packages/fuglu/scansession.py", line 302, in run_plugins
    ans = plugin.examine(suspect)
  File "/usr/local/fuglu/plugins/fuzor.py", line 55, in examine
    fuhash = FuzorDigest(msg)
  File "/usr/local/fuglu/plugins/fuzor.py", line 263, in __init__
    self.digest = self._make_hash(self.predigest)
  File "/usr/local/fuglu/plugins/fuzor.py", line 277, in _make_hash
    return hashlib.sha1(predigest).hexdigest()
TypeError: Unicode-objects must be encoded before hashing

```

hopefully without affecting py2