### PR TITLE
Updates for new fuglu version

### DIFF
--- a/sender_rewrite/srs.py
+++ b/sender_rewrite/srs.py
@@ -157,8 +157,14 @@ class SenderRewriteScheme(ScannerPlugin):
             new_hdr = '<%s>' % to_address
             
         msgrep['To'] = new_hdr
-        suspect.set_message_rep(msgrep)
-    
+        # no need to reset attachment manager because of a header change
+        try:
+            # current fuglu version
+            suspect.set_message_rep(msgrep,reset_attMgr=False)
+        except TypeError:
+            # backward compatibility
+            suspect.set_message_rep(msgrep)
+
     
     
     def examine(self, suspect):

--- a/testing/test_uriextract.py
+++ b/testing/test_uriextract.py
@@ -142,3 +142,21 @@ class URIExtractTest(unittest.TestCase):
         self.assertTrue( "http://toBeDetected.com.br/Jul2018/En/Statement/Invoice-DDDDDDDDD-DDDDDD/" in uris)
 
 
+    def test_withSuspect_newDecode(self):
+        """Test if new version of URIExtract gives same result as old one"""
+        myclass = self.__class__.__name__
+        functionNameAsString = sys._getframe().f_code.co_name
+        loggername = "%s.%s" % (myclass,functionNameAsString)
+        logger = logging.getLogger(loggername)
+
+        logger.debug("Read file content")
+        filecontent = BytesIO(mail_html).read()
+
+        logger.debug("Create suspect")
+        suspect = Suspect("auth@aaaaaa.aa","rec@aaaaaaa.aa","/dev/null")
+        suspect.set_source(filecontent)
+
+        textparts_deprecated = self.candidate.get_decoded_textparts_deprecated(suspect)
+        textparts            = self.candidate.get_decoded_textparts(suspect,bcompatible=False)
+
+        self.assertEqual(textparts_deprecated,textparts)


### PR DESCRIPTION
Updates for new fuglu version with attachment manager.
- prevent attachment manager from being recreated here because of a simple header change
- new version of get_decoded_textparts in SuspectFilter accepts a subject to make use of the attachment manager